### PR TITLE
Add route duration and dropping visits params

### DIFF
--- a/app/output.py
+++ b/app/output.py
@@ -69,6 +69,7 @@ class Vehicle:
 class Solution:
     """The solution of the problem."""
 
+    unplanned: List[InputStop]
     vehicles: List[Vehicle]
 
 
@@ -138,6 +139,14 @@ class Output:
     ):
         """Builds the class from the solution."""
 
+        unplanned_stops = []
+        for node in range(model.Size()):
+            if model.IsStart(node) or model.IsEnd(node):
+                continue
+            if solution.Value(model.NextVar(node)) == node:
+                index = manager.IndexToNode(node)
+                unplanned_stops.append(input_data.get_stop_by_index(index))
+
         output_vehicles = []
         activated_vehicles = 0
         max_travel_duration = 0
@@ -183,6 +192,11 @@ class Output:
         )
 
         return cls(
-            solutions=[Solution(vehicles=output_vehicles)],
+            solutions=[
+                Solution(
+                    vehicles=output_vehicles,
+                    unplanned=unplanned_stops,
+                ),
+            ],
             statistics=statistics,
         )

--- a/app/travel_duration.py
+++ b/app/travel_duration.py
@@ -10,7 +10,8 @@ def add_travel_duration_dimension(
     manager: pywrapcp.RoutingIndexManager,
     model: pywrapcp.RoutingModel,
     input_data: Input,
-):
+    max_travel_duration: int,
+) -> None:
     """Add the travel time as a dimension to the routing problem."""
 
     matrix = distance_matrix(input_data)
@@ -36,7 +37,7 @@ def add_travel_duration_dimension(
     travel_dimension = model.AddDimensionWithVehicleTransits(
         evaluator_indices=transit_callback_indices,
         slack_max=0,
-        capacity=24 * 3600,
+        capacity=max_travel_duration,
         fix_start_cumul_to_zero=True,
         name=dimension_name,
     )

--- a/app/unplanned.py
+++ b/app/unplanned.py
@@ -1,0 +1,20 @@
+"""Unplanned module to handle penalties for dropping visits."""
+
+from ortools.constraint_solver import pywrapcp
+
+from app.input import Input
+
+
+def add_unplanned_penalty(
+    manager: pywrapcp.RoutingIndexManager,
+    model: pywrapcp.RoutingModel,
+    input_data: Input,
+    unplanned_penalty: int,
+) -> None:
+    """Add the unplanned penalty as a disjunction to the routing problem."""
+
+    for node in range(1, len(input_data.stops) + 1):
+        model.AddDisjunction(
+            [manager.NodeToIndex(node)],
+            unplanned_penalty,
+        )


### PR DESCRIPTION
This PR adds two new parameters:

- `-max.travel.duration`: sets the maximum duration (in seconds) that a vehicle can travel for. It was hard coded before.
- `-unplanned.penalty`: sets a penalty for not visiting a stop, allowing a solution to be feasible. This allows the program to assign as many stops as it can.

